### PR TITLE
Run rc.local in bash not sh

### DIFF
--- a/etc/rc.local
+++ b/etc/rc.local
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # on the first container start we need to create SSL keys
 # TODO update if exists, but expired


### PR DESCRIPTION
Running rc.local with sh produces error:

/etc/rc.local: 7: /etc/rc.local: [[: not found                                                                                                
/etc/rc.local: 7: /etc/rc.local: -f: not found

if statement condition will always fail, resulting in new certificates every start.  
Can lead to quota being exceeded.